### PR TITLE
ANTPC Review Changes

### DIFF
--- a/2018-westphal-antpc.tex
+++ b/2018-westphal-antpc.tex
@@ -152,7 +152,7 @@ and tracked in this step: Tc, Ag, Pd, Rh, Ru, Mo and Zr \cite{flowsheet_1998}.
 
 \subsection{Electrowinning}
 
-The molten salt contains TRUs from electrorefining that are separated through electrowinning with trace uranium quantities. 
+The molten salt contains TRUs from electrorefining that are separated through electrowinning with trace uranium quantities, lanthanides and fission products. 
 With a temperature of 500$^{\circ}$C there is approximately 99 wt\% reduction in actinides and lanthanides \cite{flowsheet_1998}. 
 Throughput is also dependent on material choice for the inert electrodes whose operating voltages vary, impacting separation 
 efficiency \cite{koyama_development_2012}. A shroud surrounds the anode to provide a path for O$^{2-}$ ions to the anode and 

--- a/2018-westphal-antpc.tex
+++ b/2018-westphal-antpc.tex
@@ -150,7 +150,7 @@ the bottom of the vessel, improving separation efficiency and increasing through
 The electrorefining process also produces the fission product waste stream which requires monitoring. The following products are produced 
 and tracked in this step: Tc, Ag, Pd, Rh, Ru, Mo and Zr \cite{flowsheet_1998}. Uranium and TRU product streams separated at this stage are sent to Fuel Fabrication, while the remaining salt is reformed as an oxidant and recirculated.
 Separation efficiencies are taken after recirculation, and treated as a once-through cycle. The Cyclus time step
-is not detailed enough to benefit from analyzing inter-batch processes. Therefore, only end-state efficiencies are used rather than an explicit model.
+is not detailed enough to benefit from analyzing intra-batch processes. Therefore, only end-state efficiencies are used rather than an explicit model.
 
 \subsection{Electrowinning}
 

--- a/2018-westphal-antpc.tex
+++ b/2018-westphal-antpc.tex
@@ -168,8 +168,8 @@ time for electroreduction and electrowinning are reduced \cite{choi_electrochemi
 	\label{fig:winning}
 \end{figure}
 
-Figure \ref{fig:winning} shows that electrowinning produces Cs waste similar to electroreduction except in reduced quantities.
-Any fission products remaining in the salt from electrorefining are also removed here. In addition to physically tracked 
+Figure \ref{fig:winning} shows that electrowinning product recirculates to electrorefining after removing lanthanides.
+Fission products remaining in the salt from electrorefining are also removed here. In addition to physically tracked 
 quantities, facility power can also be monitored to observe the use of current to increase throughput. 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Method: \Cyclus Simulation}

--- a/2018-westphal-antpc.tex
+++ b/2018-westphal-antpc.tex
@@ -189,7 +189,9 @@ match results seen in \cite{flowsheet_1998}.
 
 A pyroprocessing facility can be modeled with the separations archetype at low fidelity 
 by a dedicated archetype. The goal for Pyre is to include facility configuration parameters and 
-their respective effects on the efficiency table. Efficiencies also vary according to the feed stream resulting in different 
+their respective effects on the efficiency table. Any material not separated by the four processes is categorized as
+leftover commodity, ensuring material conservation is maintained. A test will also be used to verify isotopic 
+efficiencies add up to 1. Efficiencies also vary according to the feed stream resulting in different 
 waste streams for LWR and FR fuels, for example. Multiple material choices exist for anodes and cathodes as well as other 
 design choices that require consideration. 
 

--- a/2018-westphal-antpc.tex
+++ b/2018-westphal-antpc.tex
@@ -84,8 +84,8 @@ systems within pyroprocessing with observable waste: voloxidation, electroreduct
 
 Figure \ref{fig:flowchart} demonstrates the primary separations steps involved in a general pyroprocessing facility. The main process 
 parameters are along the left side of the flowsheet, each applied to processes most significantly impacted. The boxes on the 
-right side of the processes contain the observable waste produced by each step that \Cyclus can track. Each of the main processes 
-are described below regarding information to be used by \Cyclus.
+right side of the processes contain the observable waste produced by each step that \Cyclus can track. Explicit behavior of each main process 
+is described below regarding information to be used by \Cyclus. 
 
 \subsection{Voloxidation}
 
@@ -148,11 +148,11 @@ the bottom of the vessel, improving separation efficiency and increasing through
 \end{figure}
 
 The electrorefining process also produces the fission product waste stream which requires monitoring. The following products are produced 
-and tracked in this step: Tc, Ag, Pd, Rh, Ru, Mo and Zr \cite{flowsheet_1998}.
+and tracked in this step: Tc, Ag, Pd, Rh, Ru, Mo and Zr \cite{flowsheet_1998}. Uranium and TRU product streams separated at this stage are sent to Fuel Fabrication, while the remaining salt is reformed as an oxidant and recirculated.
 
 \subsection{Electrowinning}
 
-The molten salt contains TRUs from electrorefining that are separated through electrowinning with trace uranium quantities, lanthanides and fission products. 
+The molten salt containing TRUs from electrorefining that are separated through electrowinning with trace uranium quantities, lanthanides and fission products. 
 With a temperature of 500$^{\circ}$C there is approximately 99 wt\% reduction in actinides and lanthanides \cite{flowsheet_1998}. 
 Throughput is also dependent on material choice for the inert electrodes whose operating voltages vary, impacting separation 
 efficiency \cite{koyama_development_2012}. A shroud surrounds the anode to provide a path for O$^{2-}$ ions to the anode and 
@@ -168,7 +168,9 @@ time for electroreduction and electrowinning are reduced \cite{choi_electrochemi
 	\label{fig:winning}
 \end{figure}
 
-Figure \ref{fig:winning} shows that electrowinning produces Cs waste similar to electroreduction except in reduced quantities. Any fission products remaining in the salt from electrorefining are also removed here. In addition to physically tracked quantities, facility power can also be monitored to observe the use of current to increase throughput. 
+Figure \ref{fig:winning} shows that electrowinning produces Cs waste similar to electroreduction except in reduced quantities.
+Any fission products remaining in the salt from electrorefining are also removed here. In addition to physically tracked 
+quantities, facility power can also be monitored to observe the use of current to increase throughput. 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Method: \Cyclus Simulation}
 The separations facility provided by the \Cycamore library is used as an 

--- a/2018-westphal-antpc.tex
+++ b/2018-westphal-antpc.tex
@@ -97,7 +97,7 @@ Other methods to improve the U$_3$O$_8$ reaction rate are to use alternative oxi
 
 \begin{figure}[ht]
 	\centering
-	\includegraphics[width=1\linewidth]{volox}
+	\includegraphics[width=0.8\linewidth]{volox}
 	\caption{A material balance over the voloxidation sub-process, including observables.}
 	\label{fig:volox}
 \end{figure}
@@ -142,13 +142,15 @@ the bottom of the vessel, improving separation efficiency and increasing through
 
 \begin{figure}[ht]
 	\centering
-	\includegraphics[width=0.9\linewidth]{refining}
+	\includegraphics[width=0.8\linewidth]{refining}
 	\caption{A material balance over the electrorefining sub-process, including observables.}
 	\label{fig:refining}
 \end{figure}
 
 The electrorefining process also produces the fission product waste stream which requires monitoring. The following products are produced 
 and tracked in this step: Tc, Ag, Pd, Rh, Ru, Mo and Zr \cite{flowsheet_1998}. Uranium and TRU product streams separated at this stage are sent to Fuel Fabrication, while the remaining salt is reformed as an oxidant and recirculated.
+Separation efficiencies are taken after recirculation, and treated as a once-through cycle. The Cyclus time step
+is not detailed enough to benefit from analyzing inter-batch processes. Therefore, only end-state efficiencies are used rather than an explicit model.
 
 \subsection{Electrowinning}
 

--- a/flowchart.tex
+++ b/flowchart.tex
@@ -28,7 +28,7 @@
   \node (actinide)			[redbox, right of=volox, xshift=2cm] {Actinide Waste};
   \node (decay)				[redbox, right of=reduction, xshift=2cm] {$^{90}$Sr and $^{137}$Cs waste};
   \node (refining)			[process, below of=reduction, yshift=-2cm] {Electrorefining};
-  \node (winning)			[process, below of=refining, xshift=3cm] {Electrowinning};
+  %\node (winning)			[process, below of=refining, xshift=3cm] {Electrowinning};
   \node (Li2O)	 			[greenbox, left of=reduction, xshift=-3cm, yshift=1.5cm] {Li$_2$O wt\%};
   \node (temp)	 			[greenbox, left of=refining, xshift=-3cm] {Temperature};
   \node (fission) 			[redbox, right of=refining, xshift=2cm] {Fission Products};
@@ -38,10 +38,10 @@
   \node (porosity)			[greenbox, left of=reduction, xshift=-3cm, yshift=-1.5cm] {Anode shroud \\ porosity};
   \node (LiCl)				[bluebox, below of=reduction, xshift=2cm, yshift=0.5cm] {LiCl \\ Distillation};
   \node (LiCl-KCl)			[bluebox, below of=reduction, xshift=-2cm, yshift=0.5cm] {LiCl-KCl \\ Distillation};
-  \node (salt distl)		[bluebox, below of=refining, xshift=-1cm] {Salt \\ Distillation};
-  \node (cd distl)			[bluebox, below of=winning] {Cd Distillation};
-  \node (lanth)				[redbox, below of=fission, yshift=1.5cm] {Lanthanide \\ Waste};
-  \node (fuel fab) 			[process, below of=salt distl, xshift=-2cm] {Fuel Fabrication};
+  \node (winning)			[process, below of=refining] {Electrowinning};
+  %\node (cd distl)			[bluebox, below of=winning] {Cd Distillation};
+  \node (lanth)				[redbox, right of=winning, xshift=2cm] {Lanthanide \\ Waste};
+  \node (fuel fab) 			[process, below of=winning] {Fuel Fabrication};
   
   \draw[->]					(chop) -- (volox) node[midway] {Oxide \\ Pellets};
   \draw[->]					(volox) -- (reduction) node[midway] {U$_3$O$_8$};
@@ -55,17 +55,18 @@
   \draw[->]					(temp) -- (refining);
   \draw[->]					(rotation) -- (refining);
   \draw[->]					(refining) -- (fission);
-  \draw[->]					(refining)++(0.75,-0.5) -- ++(0,-1) -- ++(0.75,0) -| (winning);
-  \draw[->]					(refining)++(-1.5,-0.5) -- ++(0,-2)(salt distl) node[midway] {U + salt};
-  \draw[->]					(salt distl)++(0.75,0.5) -- ++(0,2) (refining) node[midway] {salt};
-  \draw[->]					(salt distl) -- ++(0,-1.25) -- ++(-2,0)  node[midway] {U} -- (fuel fab);
+  %\draw[->]					(refining)++(0.75,-0.5) -- ++(0,-1) -- ++(0.75,0) -| (winning);
+  \draw[->]					(refining)++(-0.75,-0.5) -- ++(0,-2)(winning) node[near start] {U/TRU + salt};
+  \draw[->]					(winning)++(0.75,0.5) -- ++(0,2) (refining) node[near start] {salt/FP/U/TRU};
+  %\draw[->]					(winning) -- ++(0,-1.25) -- ++(-2,0)  node[midway] {U} -- (fuel fab);
+  \draw[->]					(winning) -- (fuel fab) node[midway] {U/TRU};
   \draw[->]					(reduction)++(1,-0.5) -- ++(0,-0.75) -- ++(1,0) -- ++(0,-0.75) (LiCl);
   \draw[->]					(LiCl) -- ++(0,-1.25) -- ++(-1,0) -- ++(0,-0.75) (refining);
   \draw[->]					(refining)++(-1,0.5) -- ++(0,0.75) -- ++(-1,0) -- ++(0,0.75) (LiCl-KCl);
   \draw[->]					(LiCl-KCl)++(0,0.5) -- ++(0,0.75) -- ++(1,0) -- ++(0,0.75) (reduction);
-  \draw[->]					(winning.east) -| (lanth);
-  \draw[->]					(winning) -- (cd distl);
-  \draw[->]					(cd distl) -- (fuel fab) node[midway] {U/TRU};
+  \draw[->]					(winning.east) -- (lanth);
+  %\draw[->]					(winning) -- (cd distl);
+  %\draw[->]					(cd distl) -- (fuel fab) node[midway] {U/TRU};
   \end{tikzpicture}
 \end{document}
 

--- a/refining.tex
+++ b/refining.tex
@@ -34,8 +34,8 @@
   \node (waste)				[redbox, right of=refining, xshift=2cm, yshift=0.5cm] {Waste Salt};
   \node (temp+press)		[redbox, right of=refining, xshift=2cm, yshift=2cm] {Temperature \& \\ Pressure Reading};
   \node (salt distl)		[bluebox, below of=refining, xshift=-1cm] {Salt \\ Distillation};
-  \node (fuelfab)			[process, below of=salt distl] {Fuel \\ Fabrication};
-  \node (refine2)			[process, below of=refining, xshift=2cm, yshift=-3cm] {Electrorefining};
+  \node (fuelfab)			[process, below of=salt distl, yshift=0.75cm] {Fuel \\ Fabrication};
+  \node (refine2)			[process, below of=refining, xshift=2cm, yshift=-2.25cm] {Electrorefining};
   
   
   \draw[->]					(material.east) -- ++(0.25,0) --++(0,-1.25) -- (refining);;

--- a/winning.tex
+++ b/winning.tex
@@ -28,8 +28,8 @@
   \node (cesium)			[redbox, right of=winning, xshift=2cm, yshift=1.5cm] {Lanthanides}; 
   \node (fission)			[redbox, right of=winning, xshift=2cm] {Fission Products};
   \node (power)				[redbox, right of=winning, xshift=2cm, yshift=-1.5cm] {Power Draw};
-  \node (fuel)				[process, below of=winning, xshift=-2cm] {Fuel \\ Fabrication};
-  \node (refining)			[process, below of=winning, xshift=2.25cm] {Electrorefining};
+  %\node (fuel)				[process, below of=winning, xshift=-2cm] {Fuel \\ Fabrication};
+  \node (refining)			[process, below of=winning] {Electrorefining};
   
   \draw[->]					(winning)++(0,2) -- (winning) node[midway] {LiCl-KCl + U/TRU};
   \draw[->]					(winning) -- (fission);
@@ -38,8 +38,8 @@
   \draw[->]					(time) -- (winning);
   \draw[->]					(current) -- (winning);
   \draw[->]					(shroud) -- (winning);
-  \draw[->]					(winning)++(-0.25,-0.5) -- ++(0,-1) -- ++(-1.75,0) node[midway] {U/TRU} -- (fuel);
-  \draw[->]					(winning)++(0.25,-0.5) -- ++(0,-1) -- ++(2,0) node[midway] {FP/Salt/U} -- (refining) ;
+  %\draw[->]					(winning)++(-0.25,-0.5) -- ++(0,-1) -- ++(-1.75,0) node[midway] {U/TRU} -- (fuel);
+  \draw[->]					(winning) -- (refining) node[midway] {FP/Salt/U};
 
   \end{tikzpicture}
 \end{document}

--- a/winning.tex
+++ b/winning.tex
@@ -29,7 +29,7 @@
   \node (fission)			[redbox, right of=winning, xshift=2cm] {Fission Products};
   \node (power)				[redbox, right of=winning, xshift=2cm, yshift=-1.5cm] {Power Draw};
   %\node (fuel)				[process, below of=winning, xshift=-2cm] {Fuel \\ Fabrication};
-  \node (refining)			[process, below of=winning] {Electrorefining};
+  %\node (refining)			[process, below of=winning, yshift=1cm] {Electrorefining};
   
   \draw[->]					(winning)++(0,2) -- (winning) node[midway] {LiCl-KCl + U/TRU};
   \draw[->]					(winning) -- (fission);
@@ -39,7 +39,8 @@
   \draw[->]					(current) -- (winning);
   \draw[->]					(shroud) -- (winning);
   %\draw[->]					(winning)++(-0.25,-0.5) -- ++(0,-1) -- ++(-1.75,0) node[midway] {U/TRU} -- (fuel);
-  \draw[->]					(winning) -- (refining) node[midway] {FP/Salt/U};
+  %\draw[->]					(winning) -- (refining) node[midway] {FP/Salt/U};
+  \draw[->]					(winning) -- ++(0,-2) node[midway] {FP/Salt/U};
 
   \end{tikzpicture}
 \end{document}


### PR DESCRIPTION
This pull request compiles the changes suggest by the review committee.

Graphs are updated to better reflect the re-circulation of U/TRU between the refining and winning processes. Smaller changes are also made here such as missing isotope numbers or typos. Wording is changed to clarify the reasoning behind streams in Cyclus. The Cyclus time step is not detailed enough to benefit from analyzing inter-batch processes. Therefore, only end-state efficiencies are used. 